### PR TITLE
Fix RSS feed XML parsing error by wrapping content in CDATA

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -20,7 +20,9 @@ layout: rss-feed
       <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
       <author>{{ post.author_name }}</author>
       <guid>{{ site.url }}{{ post.id }}</guid>
-      <description>{{ post.content | xml_escape }}</description>
+      
+      <!-- Fix RSS feed XML parsing error by wrapping content in CDATA -->
+      <description><![CDATA[{{ post.content }}]]></description>
     </item>
     {% endunless %}
     {% endfor %}


### PR DESCRIPTION
### Fix RSS feed XML parsing error

This PR fixes the XML parsing error occurring in the RSS feed.

The issue happens because `post.content` contains HTML characters such as `&`, `<`, and `>` which can break XML parsing even after applying `xml_escape`. When the feed is generated, these characters sometimes cause the error:

`xmlParseEntityRef: no name`

To resolve this, the post content is wrapped inside a **CDATA section**. CDATA allows raw HTML content to be included without breaking the XML structure.

#### Changes made

* Replaced:
  `<description>{{ post.content | xml_escape }}</description>`

* With:
  `<description><![CDATA[{{ post.content }}]]></description>`

This ensures that HTML inside blog posts does not cause XML parsing errors in the RSS feed.

Fixes the issue related to RSS feed parsing.
